### PR TITLE
fix: propagate probe fields and emit spec.storage to varnishd (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docs/html/
 .DS_Store
 Thumbs.db
 .worktrees/
+
+# Editor/assistant session artifacts
+.claude/

--- a/internal/controller/statefulset.go
+++ b/internal/controller/statefulset.go
@@ -62,14 +62,18 @@ func (r *VinylCacheReconciler) reconcileStatefulSet(ctx context.Context, vc *v1a
 		// Build Varnish container.
 		// The stock varnish image entrypoint passes extra args to varnishd.
 		// We need -T (admin CLI) and -S (shared secret) for the agent sidecar.
+		varnishArgs := []string{
+			"-j", "none",
+			"-T", "127.0.0.1:6082",
+			"-S", "/etc/varnish/secret",
+		}
+		// Append -s args for each spec.storage entry (after the fixed args).
+		varnishArgs = append(varnishArgs, storageArgs(vc.Spec.Storage)...)
+
 		varnishContainer := corev1.Container{
 			Name:  "varnish",
 			Image: vc.Spec.Image,
-			Args: []string{
-				"-j", "none",
-				"-T", "127.0.0.1:6082",
-				"-S", "/etc/varnish/secret",
-			},
+			Args:  varnishArgs,
 			Env: []corev1.EnvVar{
 				// Override the stock varnish image default port (80) to match
 				// the containerPort and Service definitions.
@@ -267,4 +271,29 @@ func (r *VinylCacheReconciler) reconcileStatefulSet(ctx context.Context, vc *v1a
 // boolPtr returns a pointer to a bool value.
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+// storageArgs renders spec.storage entries as varnishd "-s <name>=<type>,..."
+// command-line args. See https://varnish-cache.org/docs/7.6/reference/varnishd.html#argument-list
+// for the syntax accepted by -s.
+func storageArgs(storage []v1alpha1.StorageSpec) []string {
+	if len(storage) == 0 {
+		return nil
+	}
+	args := make([]string, 0, 2*len(storage))
+	for _, s := range storage {
+		var spec string
+		switch s.Type {
+		case "malloc":
+			// -s <name>=malloc,<size>
+			spec = fmt.Sprintf("%s=malloc,%d", s.Name, s.Size.Value())
+		case "file":
+			// -s <name>=file,<path>,<size>
+			spec = fmt.Sprintf("%s=file,%s,%d", s.Name, s.Path, s.Size.Value())
+		default:
+			continue // webhook already rejects other types; belt-and-braces skip
+		}
+		args = append(args, "-s", spec)
+	}
+	return args
 }

--- a/internal/controller/statefulset_test.go
+++ b/internal/controller/statefulset_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1alpha1 "github.com/bluedynamics/cloud-vinyl/api/v1alpha1"
+)
+
+func TestStorageArgs_Malloc(t *testing.T) {
+	got := storageArgs([]v1alpha1.StorageSpec{
+		{Name: "s0", Type: "malloc", Size: resource.MustParse("1500M")},
+	})
+	assert.Equal(t, []string{"-s", "s0=malloc,1500000000"}, got)
+}
+
+func TestStorageArgs_File(t *testing.T) {
+	got := storageArgs([]v1alpha1.StorageSpec{
+		{Name: "disk", Type: "file", Path: "/var/lib/varnish/cache.bin", Size: resource.MustParse("10Gi")},
+	})
+	assert.Equal(t, []string{"-s", "disk=file,/var/lib/varnish/cache.bin,10737418240"}, got)
+}
+
+func TestStorageArgs_Multiple(t *testing.T) {
+	got := storageArgs([]v1alpha1.StorageSpec{
+		{Name: "mem", Type: "malloc", Size: resource.MustParse("1G")},
+		{Name: "disk", Type: "file", Path: "/var/lib/varnish/cache", Size: resource.MustParse("10G")},
+	})
+	assert.Equal(t, []string{
+		"-s", "mem=malloc,1000000000",
+		"-s", "disk=file,/var/lib/varnish/cache,10000000000",
+	}, got)
+}
+
+func TestStorageArgs_Empty(t *testing.T) {
+	assert.Nil(t, storageArgs(nil))
+	assert.Nil(t, storageArgs([]v1alpha1.StorageSpec{}))
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -66,15 +66,20 @@ type TemplateData struct {
 
 // BackendDef is a single backend definition for VCL.
 type BackendDef struct {
-	Name                string
-	IP                  string
-	Port                int
-	ProbeURL            string
-	ConnectTimeout      string
-	FirstByteTimeout    string
-	BetweenBytesTimeout string
-	IdleTimeout         string
-	MaxConnections      int32
+	Name                  string
+	IP                    string
+	Port                  int
+	ProbeURL              string
+	ProbeInterval         string // e.g. "5s"; empty means use built-in default
+	ProbeTimeout          string // e.g. "2s"; empty means use built-in default
+	ProbeWindow           int32  // 0 means use built-in default
+	ProbeThreshold        int32  // 0 means use built-in default
+	ProbeExpectedResponse int32  // 0 means use built-in default (200)
+	ConnectTimeout        string
+	FirstByteTimeout      string
+	BetweenBytesTimeout   string
+	IdleTimeout           string
+	MaxConnections        int32
 }
 
 // BackendGroup is one CRD backend (spec.backends[i]) expanded to its per-pod backends,
@@ -209,6 +214,29 @@ func buildTemplateData(input Input) TemplateData {
 			}
 			if b.Probe != nil && b.Probe.URL != "" {
 				def.ProbeURL = b.Probe.URL
+				if b.Probe.Interval.Duration > 0 {
+					def.ProbeInterval = fmtDuration(b.Probe.Interval.Duration)
+				} else {
+					def.ProbeInterval = "5s"
+				}
+				if b.Probe.Timeout.Duration > 0 {
+					def.ProbeTimeout = fmtDuration(b.Probe.Timeout.Duration)
+				} else {
+					def.ProbeTimeout = "2s"
+				}
+				if b.Probe.Window > 0 {
+					def.ProbeWindow = b.Probe.Window
+				} else {
+					def.ProbeWindow = 5
+				}
+				if b.Probe.Threshold > 0 {
+					def.ProbeThreshold = b.Probe.Threshold
+				} else {
+					def.ProbeThreshold = 3
+				}
+				if b.Probe.ExpectedResponse != nil {
+					def.ProbeExpectedResponse = *b.Probe.ExpectedResponse
+				}
 			}
 			if b.ConnectionParameters != nil {
 				cp := b.ConnectionParameters

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -712,6 +712,66 @@ func TestGenerate_EmptyBackendEndpoints_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "no resolved endpoints")
 }
 
+func TestGenerate_ProbeFields_PropagatedToPerPodBackends(t *testing.T) {
+	g := newGenerator(t)
+	expected := int32(204)
+	input := generator.Input{
+		Namespace: "ns", Name: "cache",
+		Spec: &vinylv1alpha1.VinylCacheSpec{
+			Replicas: 1, Image: "vinyl:test",
+			Backends: []vinylv1alpha1.BackendSpec{{
+				Name:       "plone",
+				ServiceRef: vinylv1alpha1.ServiceRef{Name: "plone-svc"},
+				Probe: &vinylv1alpha1.BackendProbeSpec{
+					URL:              "/ok",
+					Interval:         metav1.Duration{Duration: 10 * time.Second},
+					Timeout:          metav1.Duration{Duration: 5 * time.Second},
+					Window:           10,
+					Threshold:        8,
+					ExpectedResponse: &expected,
+				},
+			}},
+		},
+		Endpoints: map[string][]generator.Endpoint{
+			"plone": {{IP: "10.0.0.1", Port: 8080}, {IP: "10.0.0.2", Port: 8080}},
+		},
+	}
+	r, err := g.Generate(input)
+	require.NoError(t, err)
+	// Both per-pod backends must carry the spec probe config, not hardcoded defaults.
+	assert.Contains(t, r.VCL, `.url = "/ok"`)
+	assert.Contains(t, r.VCL, ".interval = 10s")
+	assert.Contains(t, r.VCL, ".timeout = 5s")
+	assert.Contains(t, r.VCL, ".window = 10")
+	assert.Contains(t, r.VCL, ".threshold = 8")
+	assert.Contains(t, r.VCL, ".expected_response = 204")
+	assert.NotContains(t, r.VCL, ".timeout = 2s",
+		"hardcoded timeout must not leak through when spec sets a value")
+}
+
+func TestGenerate_ProbeDefaults_AppliedWhenFieldsUnset(t *testing.T) {
+	g := newGenerator(t)
+	input := generator.Input{
+		Namespace: "ns", Name: "cache",
+		Spec: &vinylv1alpha1.VinylCacheSpec{
+			Replicas: 1, Image: "vinyl:test",
+			Backends: []vinylv1alpha1.BackendSpec{{
+				Name:       "plone",
+				ServiceRef: vinylv1alpha1.ServiceRef{Name: "plone-svc"},
+				Probe:      &vinylv1alpha1.BackendProbeSpec{URL: "/ok"},
+			}},
+		},
+		Endpoints: map[string][]generator.Endpoint{"plone": {{IP: "10.0.0.1", Port: 8080}}},
+	}
+	r, err := g.Generate(input)
+	require.NoError(t, err)
+	assert.Contains(t, r.VCL, ".interval = 5s", "default interval")
+	assert.Contains(t, r.VCL, ".timeout = 2s", "default timeout")
+	assert.Contains(t, r.VCL, ".window = 5", "default window")
+	assert.Contains(t, r.VCL, ".threshold = 3", "default threshold")
+	assert.NotContains(t, r.VCL, ".expected_response", "no expected_response when unset")
+}
+
 func TestGenerate_FullOverride_BypassesEmptyBackendCheck(t *testing.T) {
 	g := newGenerator(t)
 	input := generator.Input{

--- a/internal/generator/templates/backends.vcl.tmpl
+++ b/internal/generator/templates/backends.vcl.tmpl
@@ -6,10 +6,13 @@ backend {{ .Name }} {
 {{- if .ProbeURL }}
     .probe = {
         .url = "{{ .ProbeURL }}";
-        .interval = 5s;
-        .timeout = 2s;
-        .window = 5;
-        .threshold = 3;
+        .interval = {{ .ProbeInterval }};
+        .timeout = {{ .ProbeTimeout }};
+        .window = {{ .ProbeWindow }};
+        .threshold = {{ .ProbeThreshold }};
+{{- if .ProbeExpectedResponse }}
+        .expected_response = {{ .ProbeExpectedResponse }};
+{{- end }}
     }
 {{- end }}
 {{- if .ConnectTimeout }}


### PR DESCRIPTION
## Summary

Two production bugs in v0.4.0 surfaced in #37, both dropping user spec on the floor:

- **Probe fields beyond `.url` were ignored.** The backend template hardcoded `interval=5s timeout=2s window=5 threshold=3`. Prod saw healthy-but-slow Plone pods marked sick by the 2s timeout, which the shard director with `healthy=CHOSEN` turned into a 503 storm.
- **`spec.storage` never reached varnishd.** The varnish container had no `-s` args, so varnishd used the stock image default `-s malloc,100M`. A spec requesting 1500M ran with 100M; 352k allocation failures, 24% hit ratio.

## Fix

- Generator resolves all `backends[].probe` fields (Interval, Timeout, Window, Threshold, ExpectedResponse) with the previous hardcoded values as defaults — no behaviour change for users who only set `.url`. `expected_response` is emitted only when set.
- `storageArgs()` helper emits one `-s <name>=<type>,<options>` per `spec.storage[]` entry. Malloc → bytes. File → path,bytes. Unknown types are skipped (webhook already rejects them).

## Tests

- `TestGenerate_ProbeFields_PropagatedToPerPodBackends` — explicit spec values reach every per-pod backend.
- `TestGenerate_ProbeDefaults_AppliedWhenFieldsUnset` — defaults match previously hardcoded values.
- `TestStorageArgs_{Malloc,File,Multiple,Empty}` — the four interesting shapes.

Full `go test ./...` green.

## Test plan (reviewer)

- [ ] Install `ghcr.io/bluedynamics/cloud-vinyl-operator:0.4.1` in a test cluster.
- [ ] Apply a VinylCache with `spec.storage: [{name: s0, type: malloc, size: 1500M}]` and `spec.backends[0].probe: {timeout: 5s, window: 10, threshold: 8}`.
- [ ] `kubectl exec` into the varnish pod: confirm `varnishadm vcl.show -v` shows the configured probe values and `ps -f 1` shows `-s s0=malloc,1500000000`.

Refs #37