### PR TITLE
feat: honor spec.director.shard.{by,healthy} in cluster VCL (#36)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -68,6 +68,15 @@ type TemplateData struct {
 	PeerDefs         []BackendDef
 	UseShardDirector bool
 	DirectorName     string
+
+	// ClusterShardBy is the hash-key strategy for the cluster-peer shard
+	// director's request-time .backend() call. Defaults to "URL" (matches
+	// previous hardcoded behaviour). Overridable via spec.director.shard.by.
+	ClusterShardBy string
+	// ClusterShardHealthy is the health policy the cluster-peer director
+	// evaluates at request time. Empty means "Varnish default" — template
+	// omits the healthy= argument. Overridable via spec.director.shard.healthy.
+	ClusterShardHealthy string
 }
 
 // BackendDef is a single backend definition for VCL.
@@ -205,6 +214,20 @@ func buildTemplateData(input Input) TemplateData {
 	data.HasESI = hasESI
 
 	data.UseShardDirector = input.Spec.Director.Type == "shard" || input.Spec.Director.Type == ""
+
+	// Cluster-peer shard director parameters (request-time).
+	// Fall back to "URL" for by (preserves pre-#36 behaviour) and to empty
+	// for healthy (so the template omits the arg and Varnish uses its default).
+	data.ClusterShardBy = "URL"
+	data.ClusterShardHealthy = ""
+	if input.Spec.Director.Shard != nil {
+		if input.Spec.Director.Shard.By != "" {
+			data.ClusterShardBy = input.Spec.Director.Shard.By
+		}
+		if input.Spec.Director.Shard.Healthy != "" {
+			data.ClusterShardHealthy = input.Spec.Director.Shard.Healthy
+		}
+	}
 
 	// Build backend groups from spec backends + resolved endpoints.
 	for _, b := range input.Spec.Backends {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -791,6 +791,60 @@ func TestGenerate_FullOverride_BypassesEmptyBackendCheck(t *testing.T) {
 	assert.Contains(t, r.VCL, "user override")
 }
 
+func TestGenerate_ClusterShardBy_DefaultsToURL(t *testing.T) {
+	g := newGenerator(t)
+	input := makeMinimalInput()
+	input.Spec.Cluster = vinylv1alpha1.ClusterSpec{Enabled: true}
+	input.Peers = []generator.PeerBackend{
+		{Name: "my_cache_0", IP: "10.0.2.1", Port: 8080},
+		{Name: "my_cache_1", IP: "10.0.2.2", Port: 8080},
+	}
+	r, err := g.Generate(input)
+	require.NoError(t, err)
+	assert.Contains(t, r.VCL, ".backend(by=URL)",
+		"cluster-peer director must default to by=URL when spec.director.shard.by is unset")
+	assert.NotContains(t, r.VCL, "healthy=",
+		"no healthy= argument when spec.director.shard.healthy is unset")
+}
+
+func TestGenerate_ClusterShardBy_HonorsSpecOverride(t *testing.T) {
+	g := newGenerator(t)
+	input := makeMinimalInput()
+	input.Spec.Cluster = vinylv1alpha1.ClusterSpec{Enabled: true}
+	input.Spec.Director = vinylv1alpha1.DirectorSpec{
+		Type:  "shard",
+		Shard: &vinylv1alpha1.ShardSpec{By: "HASH"},
+	}
+	input.Peers = []generator.PeerBackend{
+		{Name: "my_cache_0", IP: "10.0.2.1", Port: 8080},
+		{Name: "my_cache_1", IP: "10.0.2.2", Port: 8080},
+	}
+	r, err := g.Generate(input)
+	require.NoError(t, err)
+	assert.Contains(t, r.VCL, ".backend(by=HASH)",
+		"spec.director.shard.by=HASH must reach vcl_recv")
+	assert.NotContains(t, r.VCL, ".backend(by=URL)",
+		"hardcoded URL must not leak through when spec overrides it")
+}
+
+func TestGenerate_ClusterShardHealthy_HonorsSpecOverride(t *testing.T) {
+	g := newGenerator(t)
+	input := makeMinimalInput()
+	input.Spec.Cluster = vinylv1alpha1.ClusterSpec{Enabled: true}
+	input.Spec.Director = vinylv1alpha1.DirectorSpec{
+		Type:  "shard",
+		Shard: &vinylv1alpha1.ShardSpec{Healthy: "ALL"},
+	}
+	input.Peers = []generator.PeerBackend{
+		{Name: "my_cache_0", IP: "10.0.2.1", Port: 8080},
+		{Name: "my_cache_1", IP: "10.0.2.2", Port: 8080},
+	}
+	r, err := g.Generate(input)
+	require.NoError(t, err)
+	assert.Contains(t, r.VCL, ".backend(by=URL, healthy=ALL)",
+		"spec.director.shard.healthy=ALL must reach vcl_recv alongside by=")
+}
+
 func TestGenerate_OperatorIP_PresentInPurgeACL(t *testing.T) {
 	g := newGenerator(t)
 	input := makeMinimalInput()

--- a/internal/generator/templates/vcl_recv.vcl.tmpl
+++ b/internal/generator/templates/vcl_recv.vcl.tmpl
@@ -17,7 +17,7 @@ sub vcl_recv {
     # Route to responsible peer; if already routed, proceed to cache lookup
     if (!req.http.X-Vinyl-Shard) {
         set req.http.X-Vinyl-Shard = "1";
-        set req.backend_hint = {{ .DirectorName }}.backend(by=URL);
+        set req.backend_hint = {{ .DirectorName }}.backend(by={{ .ClusterShardBy }}{{ if .ClusterShardHealthy }}, healthy={{ .ClusterShardHealthy }}{{ end }});
         return(pass);
     }
     unset req.http.X-Vinyl-Shard;


### PR DESCRIPTION
## Summary

`spec.director.shard.by` (HASH|URL) and `spec.director.shard.healthy` (CHOSEN|ALL) were persisted on the CR and defaulted by the webhook, but the generator hardcoded `by=URL` in `vcl_recv.vcl.tmpl:20` and omitted `healthy` entirely — so users setting these fields saw no effect.

## Fix

Thread both values through `TemplateData` (`ClusterShardBy` / `ClusterShardHealthy`) and emit them in the cluster-peer director's request-time `.backend()` call:

```vcl
set req.backend_hint = <director>.backend(by=<by>[, healthy=<hl>]);
```

- `by` defaults to `URL` — preserves pre-fix behaviour.
- `healthy`, when unset, is omitted so Varnish uses its own default.

## Tests

- `TestGenerate_ClusterShardBy_DefaultsToURL` — default path, no `healthy=` leaked.
- `TestGenerate_ClusterShardBy_HonorsSpecOverride` — `spec.director.shard.by: HASH` lands.
- `TestGenerate_ClusterShardHealthy_HonorsSpecOverride` — `spec.director.shard.healthy: ALL` lands alongside `by=`.

Full `go test ./...` green.

## Out of scope

Per-backend directors (default: shard) leave `by`/`healthy` to the user's snippet — they are request-time `.backend()` arguments and there is no operator-emitted default routing for multi-backend configs. Users who want per-backend `by`/`healthy` must pass them in their own `vcl_recv` snippet, e.g.:

```vcl
set req.backend_hint = plone.backend(by=HASH, healthy=ALL);
```

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)