### PR TITLE
ci(e2e): reduce chainsaw parallelism from 3 to 2

### DIFF
--- a/.github/workflows/e2e-chainsaw.yml
+++ b/.github/workflows/e2e-chainsaw.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           chainsaw test \
             --test-dir e2e/tests \
-            --parallel 3 \
+            --parallel 2 \
             --exclude-test-regex "(ha-operator|drift-detection)"
 
       - name: Run sequential E2E tests


### PR DESCRIPTION
## Summary
- The E2E Chainsaw job on main has been red since the merge of #45 (run [26574487815](https://github.com/bluedynamics/cloud-vinyl/actions/runs/26574487815)).
- Two heavy tests (`cluster-routing`, `per-backend-directors`) intermittently fail with `context deadline exceeded` on POSTs to the VinylCache validating webhook.
- The same PR branch had two prior E2E failures before passing, so this looks like flakiness under parallel load, not a code regression.
- The operator log around the failures shows the webhook is still answering for other namespaces (it's slow, not dead) and shows StatefulSet optimistic-concurrency conflicts — both consistent with contention rather than a bug.

Dropping `--parallel 3` → `--parallel 2` to give the single-pod operator/webhook more headroom on the GitHub runner.

## Test plan
- [ ] E2E Chainsaw job goes green on this PR
- [ ] Total wall-clock time stays within the 45-minute job timeout (was ~8m at parallel=3; expect ~10-12m at parallel=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)