### PR TITLE
fix(chart): add additionalLabels to PrometheusRule template

### DIFF
--- a/charts/cloud-vinyl/templates/prometheusrule.yaml
+++ b/charts/cloud-vinyl/templates/prometheusrule.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "cloud-vinyl.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: cloud-vinyl
+    {{- with .Values.monitoring.prometheusRules.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   groups:
     - name: cloud-vinyl
@@ -36,7 +39,7 @@ spec:
             summary: "All Varnish pods unreachable for {{ "{{" }} $labels.cache {{ "}}" }}"
             description: "Cannot reach any Varnish pod in cache {{ "{{" }} $labels.cache {{ "}}" }}. Cache is not serving requests correctly."
         - alert: VinylCacheBackendUnhealthy
-          expr: 'vinyl_backend_health == 0'
+          expr: 'varnish_backend_happy == 0'
           for: 5m
           labels:
             severity: warning
@@ -44,7 +47,7 @@ spec:
             summary: "Backend {{ "{{" }} $labels.backend {{ "}}" }} unhealthy"
             description: "Backend {{ "{{" }} $labels.backend {{ "}}" }} for cache {{ "{{" }} $labels.cache {{ "}}" }} is reporting unhealthy."
         - alert: VinylCacheLowHitRatio
-          expr: 'vinyl_cache_hit_ratio < 0.5'
+          expr: '(sum(rate(varnish_main_cache_hit[5m])) by (namespace, pod)) / (sum(rate(varnish_main_cache_hit[5m])) by (namespace, pod) + sum(rate(varnish_main_cache_miss[5m])) by (namespace, pod)) < 0.5'
           for: 15m
           labels:
             severity: warning

--- a/charts/cloud-vinyl/tests/monitoring_test.yaml
+++ b/charts/cloud-vinyl/tests/monitoring_test.yaml
@@ -34,6 +34,29 @@ tests:
           path: spec.groups[0].name
           value: cloud-vinyl
 
+  - it: PrometheusRule should apply additionalLabels
+    template: prometheusrule.yaml
+    set:
+      monitoring.prometheusRules.enabled: true
+      monitoring.prometheusRules.additionalLabels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+
+  - it: PrometheusRule hit-ratio and backend alerts use exporter metrics
+    template: prometheusrule.yaml
+    set:
+      monitoring.prometheusRules.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[4].expr
+          pattern: varnish_main_cache_hit
+      - equal:
+          path: spec.groups[0].rules[3].expr
+          value: "varnish_backend_happy == 0"
+
   - it: ServiceMonitor should not be rendered when disabled
     template: servicemonitor.yaml
     set:

--- a/charts/cloud-vinyl/values.schema.json
+++ b/charts/cloud-vinyl/values.schema.json
@@ -116,7 +116,8 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "enabled": {"type": "boolean"}
+            "enabled": {"type": "boolean"},
+            "additionalLabels": {"type": "object"}
           }
         },
         "serviceMonitor": {

--- a/charts/cloud-vinyl/values.yaml
+++ b/charts/cloud-vinyl/values.yaml
@@ -64,6 +64,10 @@ monitoring:
   prometheusRules:
     # Deploy a PrometheusRule with 10 pre-defined alerts (architektur.md §8.5).
     enabled: false
+    # Extra labels for the PrometheusRule, e.g. to match a Prometheus ruleSelector
+    # such as {release: kube-prometheus-stack}. Without a matching label the rule
+    # is created but never loaded by Prometheus.
+    additionalLabels: {}
   serviceMonitor:
     # Deploy a ServiceMonitor for Prometheus Operator scraping.
     enabled: false


### PR DESCRIPTION
Closes #50.

## Problem
The chart's `ServiceMonitor` template supports `monitoring.serviceMonitor.additionalLabels`, but `PrometheusRule` did not. On kube-prometheus-stack installs that keep the default `ruleSelector` (`matchLabels: {release: <name>}`), the generated PrometheusRule is created but **never loaded** — the bundled alerts silently never fire, with no remediation from chart values.

## Fix
- Mirror the ServiceMonitor pattern: add `monitoring.prometheusRules.additionalLabels` (default `{}`) to `templates/prometheusrule.yaml`, `values.yaml`, and `values.schema.json`. Backward-compatible.
- Operators can now set e.g. `prometheusRules.additionalLabels: {release: kube-prometheus-stack}` so the rule is selected.

## Drive-by (related regression from #49 / v0.5.0)
This chart template is a hand-maintained copy of the alerts and still referenced the gauges removed in v0.5.0. Synced the two affected exprs to the exporter metrics, matching `internal/monitoring/prometheusrule.go`:
- `VinylCacheBackendUnhealthy`: `vinyl_backend_health == 0` → `varnish_backend_happy == 0`
- `VinylCacheLowHitRatio`: `vinyl_cache_hit_ratio < 0.5` → exporter cache hit/miss ratio

Without this, those two bundled alerts referenced non-existent metrics and could never fire.

## Testing
- `helm lint` clean.
- `helm unittest charts/cloud-vinyl` — 55/55 pass (added: additionalLabels rendered; hit-ratio/backend alerts use exporter metrics).
- `helm template` confirms the `release` label is applied and both exprs render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)