### PR TITLE
fix(exporter): build & publish the varnish-exporter sidecar image

### DIFF
--- a/.github/workflows/release-exporter.yml
+++ b/.github/workflows/release-exporter.yml
@@ -1,0 +1,82 @@
+name: Release Exporter Image
+
+# Builds and publishes ghcr.io/bluedynamics/varnish-exporter:<EXPORTER_VERSION>,
+# the varnish-exporter sidecar used by spec.monitoring.exporter. This image is
+# essentially static (pinned upstream exporter + pinned varnish base), so it is
+# built on demand rather than on every cloud-vinyl release.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.exporter"
+      - ".github/workflows/release-exporter.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/bluedynamics/varnish-exporter
+  EXPORTER_VERSION: "1.6.1"
+  VARNISH_IMAGE: "varnish:7.6"
+
+jobs:
+  docker-build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Platform tag
+        id: meta
+        run: |
+          PLATFORM_TAG="${{ matrix.platform }}"
+          echo "platform_tag=${PLATFORM_TAG//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push per-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.exporter
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          build-args: |
+            EXPORTER_VERSION=${{ env.EXPORTER_VERSION }}
+            VARNISH_IMAGE=${{ env.VARNISH_IMAGE }}
+          tags: ${{ env.IMAGE }}:${{ env.EXPORTER_VERSION }}-${{ steps.meta.outputs.platform_tag }}
+
+  docker-manifest:
+    needs: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create "${IMAGE}:${EXPORTER_VERSION}" \
+            "${IMAGE}:${EXPORTER_VERSION}-linux-amd64" \
+            "${IMAGE}:${EXPORTER_VERSION}-linux-arm64"
+          docker manifest push "${IMAGE}:${EXPORTER_VERSION}"

--- a/Dockerfile.exporter
+++ b/Dockerfile.exporter
@@ -1,0 +1,40 @@
+# varnish-exporter: a thin, distroless image that runs the upstream
+# prometheus_varnish_exporter and bundles a matching `varnishstat` (plus its
+# shared libraries) copied from the official varnish image. The exporter shells
+# out to varnishstat, so the bundled varnishstat MUST match the varnishd version
+# that writes the VSM — keep VARNISH_IMAGE in sync with the cache image.
+#
+# Published as ghcr.io/bluedynamics/varnish-exporter:<EXPORTER_VERSION>.
+
+ARG VARNISH_IMAGE=varnish:7.6
+ARG EXPORTER_VERSION=1.6.1
+
+# Build the exporter from source. Upstream ships no arm64 binary for 1.6.1, and
+# the project is pure Go (it execs varnishstat; no cgo), so it cross-compiles.
+FROM golang:1.25 AS build
+ARG EXPORTER_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+RUN git clone --depth 1 --branch "${EXPORTER_VERSION}" \
+        https://github.com/jonnenauha/prometheus_varnish_exporter /src
+WORKDIR /src
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+        go build -trimpath -o /out/prometheus_varnish_exporter .
+
+# Source of a matching varnishstat + its runtime libraries.
+FROM ${VARNISH_IMAGE} AS varnish
+
+# Must match the Debian release of VARNISH_IMAGE (varnish:7.6 = Debian 13/trixie,
+# glibc 2.41) so the copied varnishstat/libvarnishapi find a compatible glibc.
+FROM gcr.io/distroless/base-debian13:nonroot
+# varnishstat and the libraries it needs that distroless/base does not provide.
+# (libc, libm and the loader come from distroless/base.)
+COPY --from=varnish /usr/bin/varnishstat /usr/bin/varnishstat
+COPY --from=varnish /usr/lib/libvarnishapi.so.3* /usr/lib/
+COPY --from=varnish /lib/*-linux-gnu/libncursesw.so.6 /usr/lib/libncursesw.so.6
+COPY --from=varnish /lib/*-linux-gnu/libtinfo.so.6 /usr/lib/libtinfo.so.6
+COPY --from=varnish /lib/*-linux-gnu/libpcre2-8.so.0 /usr/lib/libpcre2-8.so.0
+COPY --from=build /out/prometheus_varnish_exporter /usr/bin/prometheus_varnish_exporter
+# 9131 is the exporter's default listen port.
+EXPOSE 9131
+ENTRYPOINT ["/usr/bin/prometheus_varnish_exporter"]

--- a/docs/sources/how-to/setup-monitoring.md
+++ b/docs/sources/how-to/setup-monitoring.md
@@ -57,6 +57,15 @@ The exporter image and resources can be overridden:
         limits: {cpu: 200m, memory: 64Mi}
 ```
 
+```{note}
+The exporter shells out to `varnishstat`, so the default image
+`ghcr.io/bluedynamics/varnish-exporter:1.6.1` bundles a `varnishstat` built for
+**Varnish 7.x** (matching the `varnish:7.6` cache image used by default). If you
+run a different Varnish major version, override `exporter.image` with a matching
+build — a mismatched `varnishstat` cannot read the VSM and the sidecar will not
+produce metrics.
+```
+
 ## Show the cache hit rate in Grafana
 
 The hit ratio is computed from the exporter's raw counters, not from an operator


### PR DESCRIPTION
Closes #52.

## Problem
`spec.monitoring.exporter` defaults to `ghcr.io/bluedynamics/varnish-exporter:1.6.1`, but that image was **never built or published** — so `monitoring.exporter.enabled: true` lands in `ImagePullBackOff` and the v0.5.x cache hit-ratio / backend-health metrics never work out of the box.

## Approach (option chosen: distroless + bundled varnishstat)
`prometheus_varnish_exporter` is pure Go and **shells out to `varnishstat`** — it does not link libvarnishapi. So the image must ship a `varnishstat` matching the varnishd that writes the VSM.

- `Dockerfile.exporter`: distroless (`base-debian13`, matching `varnish:7.6` = Debian 13/glibc 2.41) that runs upstream `prometheus_varnish_exporter` 1.6.1 (built **from source** — upstream ships no arm64 prebuilt) and bundles `varnishstat` + its runtime libs (`libvarnishapi`, `libncursesw`, `libtinfo`, `libpcre2`) copied from the official `varnish:7.6` image. ~42 MB.
- `release-exporter.yml`: builds + pushes `varnish-exporter:1.6.1` multi-arch (amd64 + arm64) on demand (manual dispatch or `Dockerfile.exporter` changes).

No operator code change is needed — the v0.5.0 sidecar wiring is correct; only the image was missing.

## Local verification (docker)
- `varnishstat -V` resolves inside the image → `varnish-7.6.5`.
- varnishd writing a VSM to a shared volume + the exporter container (same hostname, **no args**, **read-only** VSM — mirroring the same-pod sidecar) → exporter scrapes and exposes `varnish_main_cache_hit`, `varnish_main_cache_miss`, `varnish_backend_happy` (exactly the metrics the v0.5.x dashboard/alerts use).

## Notes
- The bundled `varnishstat` is pinned to **Varnish 7.x**; non-7.x users must override `exporter.image` (documented in `setup-monitoring.md`). Digest pinning (architektur.md) can be a follow-up.
- **Separate finding:** the `ghcr.io/bluedynamics/cloud-vinyl-varnish` package is mispublished — every tag (`0.1.0`–`0.1.3`, `latest`) has entrypoint `/agent` and contains no Varnish. Worth a separate issue; not required for this fix (the real cache image is the official `varnish:7.6`).

## After merge
`release-exporter.yml` triggers on the `Dockerfile.exporter` change and publishes the image; then the default works unchanged. Acceptance criterion 2 (VinylCache reaches Ready in-cluster) needs a real cluster — validated equivalently here via docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)