### PR TITLE
fix(monitoring): ServiceMonitor selector/port must match generated Services (fixes #54)

### DIFF
--- a/internal/monitoring/servicemonitor.go
+++ b/internal/monitoring/servicemonitor.go
@@ -42,14 +42,20 @@ func GenerateServiceMonitor(name, namespace string) *ServiceMonitor {
 			},
 		},
 		Spec: ServiceMonitorSpec{
+			// Must agree with the labels and port name the reconciler puts on
+			// the generated Services (internal/controller/service.go): they
+			// carry `app: <name>` and expose the exporter on a port named
+			// `exporter`. Selecting on `app.kubernetes.io/name` / port
+			// `metrics` matched nothing, so Prometheus never scraped the
+			// exporter despite a healthy sidecar.
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/name": name,
+					"app": name,
 				},
 			},
 			Endpoints: []Endpoint{
 				{
-					Port:          "metrics",
+					Port:          "exporter",
 					Path:          "/metrics",
 					Interval:      "30s",
 					ScrapeTimeout: "10s",

--- a/internal/monitoring/servicemonitor_test.go
+++ b/internal/monitoring/servicemonitor_test.go
@@ -15,3 +15,12 @@ func TestGenerateServiceMonitor_BasicFields(t *testing.T) {
 	assert.NotEmpty(t, sm.Spec.Endpoints)
 	assert.Equal(t, "30s", sm.Spec.Endpoints[0].Interval)
 }
+
+// The selector and endpoint port must match what the reconciler puts on the
+// generated Services (internal/controller/service.go), otherwise Prometheus
+// gets no target and never scrapes the exporter.
+func TestGenerateServiceMonitor_SelectorAndPortMatchService(t *testing.T) {
+	sm := monitoring.GenerateServiceMonitor("test", "ns")
+	assert.Equal(t, map[string]string{"app": "test"}, sm.Spec.Selector.MatchLabels)
+	assert.Equal(t, "exporter", sm.Spec.Endpoints[0].Port)
+}


### PR DESCRIPTION
## Problem

With `spec.monitoring.serviceMonitor.enabled: true`, the exporter sidecar runs and serves `/metrics` correctly on the `exporter` port (:9131), but Prometheus never scrapes it: the generated ServiceMonitor doesn't match the generated Services.

- **Selector:** SM uses `app.kubernetes.io/name: <name>`, but `reconcileServices` labels the Services `app: <name>` (+ `vinyl.bluedynamics.eu/cache-name`). → matches nothing.
- **Port:** SM endpoint uses `port: metrics`, but the Service names the exporter port `exporter`. → wrong port even if selected.

Result: empty endpoints, no Prometheus target, zero `varnish_*`/`vinyl_*` series despite a healthy exporter (verified in a live cluster: exporter `/metrics` returns 836 lines incl. `varnish_main_cache_hit/miss`, `varnish_backend_happy`).

## Fix

`internal/monitoring/servicemonitor.go`: select on `app: <name>` and reference endpoint port `exporter`, matching `internal/controller/service.go`. Added a unit-test assertion so the selector/port can't drift from the Service again.

`go build/vet/test ./...` all pass. Fixes #54.