### PR TITLE
fix(networkpolicy): open exporter port 9131 so Prometheus can scrape

### DIFF
--- a/internal/controller/endpoints_test.go
+++ b/internal/controller/endpoints_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -26,6 +27,7 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	require.NoError(t, corev1.AddToScheme(s))
 	require.NoError(t, appsv1.AddToScheme(s))
 	require.NoError(t, discoveryv1.AddToScheme(s))
+	require.NoError(t, networkingv1.AddToScheme(s))
 	require.NoError(t, v1alpha1.AddToScheme(s))
 	return s
 }

--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -210,7 +210,7 @@ func (r *VinylCacheReconciler) reconcileExporterNetworkPolicy(ctx context.Contex
 	exp := vc.Spec.Monitoring.Exporter
 	if exp == nil || !exp.Enabled {
 		// Exporter disabled: remove a previously created policy if present.
-		if err := r.Client.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting exporter NetworkPolicy: %w", err)
 		}
 		return nil

--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,7 +31,7 @@ import (
 	v1alpha1 "github.com/bluedynamics/cloud-vinyl/api/v1alpha1"
 )
 
-// reconcileNetworkPolicies creates or updates the three NetworkPolicies for a VinylCache.
+// reconcileNetworkPolicies creates or updates the NetworkPolicies for a VinylCache.
 func (r *VinylCacheReconciler) reconcileNetworkPolicies(ctx context.Context, vc *v1alpha1.VinylCache) error {
 	if err := r.reconcileTrafficNetworkPolicy(ctx, vc); err != nil {
 		return err
@@ -39,6 +40,9 @@ func (r *VinylCacheReconciler) reconcileNetworkPolicies(ctx context.Context, vc 
 		return err
 	}
 	if err := r.reconcileAgentNetworkPolicy(ctx, vc); err != nil {
+		return err
+	}
+	if err := r.reconcileExporterNetworkPolicy(ctx, vc); err != nil {
 		return err
 	}
 	return nil
@@ -185,6 +189,67 @@ func (r *VinylCacheReconciler) reconcileAgentNetworkPolicy(ctx context.Context, 
 	})
 	if err != nil {
 		return fmt.Errorf("reconciling agent NetworkPolicy: %w", err)
+	}
+	return nil
+}
+
+// reconcileExporterNetworkPolicy allows ingress to the varnish-exporter metrics
+// port so Prometheus can scrape it. The operator cannot know which namespace
+// Prometheus runs in, and the exposed data is read-only, low-sensitivity Varnish
+// metrics, so ingress is allowed from all sources — consistent with the
+// always-open Varnish HTTP port. The policy exists only while the exporter
+// sidecar is enabled; when disabled, a stale policy is removed.
+func (r *VinylCacheReconciler) reconcileExporterNetworkPolicy(ctx context.Context, vc *v1alpha1.VinylCache) error {
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vc.Name + "-exporter",
+			Namespace: vc.Namespace,
+		},
+	}
+
+	exp := vc.Spec.Monitoring.Exporter
+	if exp == nil || !exp.Enabled {
+		// Exporter disabled: remove a previously created policy if present.
+		if err := r.Client.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting exporter NetworkPolicy: %w", err)
+		}
+		return nil
+	}
+
+	port := exporterPort
+	if exp.Port != 0 {
+		port = exp.Port
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, func() error {
+		if err := ctrl.SetControllerReference(vc, np, r.Scheme); err != nil {
+			return err
+		}
+
+		np.Labels = map[string]string{labelVinylCacheName: vc.Name}
+
+		exporterPortVal := intstr.FromInt32(port)
+		proto := corev1.ProtocolTCP
+
+		np.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": vc.Name},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					// Empty From = allow from all sources, so Prometheus can scrape
+					// regardless of its namespace. Exporter metrics are read-only.
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &exporterPortVal, Protocol: &proto},
+					},
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("reconciling exporter NetworkPolicy: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/networkpolicy_test.go
+++ b/internal/controller/networkpolicy_test.go
@@ -27,7 +27,7 @@ func netpolVC(exp *v1alpha1.ExporterSpec) *v1alpha1.VinylCache {
 func getExporterNetpol(t *testing.T, r *VinylCacheReconciler, vc *v1alpha1.VinylCache) (*networkingv1.NetworkPolicy, error) {
 	t.Helper()
 	np := &networkingv1.NetworkPolicy{}
-	err := r.Client.Get(context.Background(), types.NamespacedName{Name: vc.Name + "-exporter", Namespace: vc.Namespace}, np)
+	err := r.Get(context.Background(), types.NamespacedName{Name: vc.Name + "-exporter", Namespace: vc.Namespace}, np)
 	return np, err
 }
 

--- a/internal/controller/networkpolicy_test.go
+++ b/internal/controller/networkpolicy_test.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/bluedynamics/cloud-vinyl/api/v1alpha1"
+)
+
+func netpolVC(exp *v1alpha1.ExporterSpec) *v1alpha1.VinylCache {
+	return &v1alpha1.VinylCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cache", Namespace: "app"},
+		Spec: v1alpha1.VinylCacheSpec{
+			Monitoring: v1alpha1.MonitoringSpec{Exporter: exp},
+		},
+	}
+}
+
+func getExporterNetpol(t *testing.T, r *VinylCacheReconciler, vc *v1alpha1.VinylCache) (*networkingv1.NetworkPolicy, error) {
+	t.Helper()
+	np := &networkingv1.NetworkPolicy{}
+	err := r.Client.Get(context.Background(), types.NamespacedName{Name: vc.Name + "-exporter", Namespace: vc.Namespace}, np)
+	return np, err
+}
+
+func TestReconcileExporterNetworkPolicy_OpensPortWhenEnabled(t *testing.T) {
+	sch := newScheme(t)
+	vc := netpolVC(&v1alpha1.ExporterSpec{Enabled: true})
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(vc).Build()
+	r := &VinylCacheReconciler{Client: cli, Scheme: sch}
+
+	require.NoError(t, r.reconcileExporterNetworkPolicy(context.Background(), vc))
+
+	np, err := getExporterNetpol(t, r, vc)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "my-cache"}, np.Spec.PodSelector.MatchLabels)
+	require.Len(t, np.Spec.Ingress, 1)
+	// Empty From => allow from all sources (Prometheus in any namespace).
+	assert.Empty(t, np.Spec.Ingress[0].From)
+	require.Len(t, np.Spec.Ingress[0].Ports, 1)
+	assert.Equal(t, int(exporterPort), np.Spec.Ingress[0].Ports[0].Port.IntValue())
+}
+
+func TestReconcileExporterNetworkPolicy_CustomPort(t *testing.T) {
+	sch := newScheme(t)
+	vc := netpolVC(&v1alpha1.ExporterSpec{Enabled: true, Port: 19131})
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(vc).Build()
+	r := &VinylCacheReconciler{Client: cli, Scheme: sch}
+
+	require.NoError(t, r.reconcileExporterNetworkPolicy(context.Background(), vc))
+
+	np, err := getExporterNetpol(t, r, vc)
+	require.NoError(t, err)
+	require.Len(t, np.Spec.Ingress, 1)
+	require.Len(t, np.Spec.Ingress[0].Ports, 1)
+	assert.Equal(t, 19131, np.Spec.Ingress[0].Ports[0].Port.IntValue())
+}
+
+func TestReconcileExporterNetworkPolicy_AbsentWhenDisabled(t *testing.T) {
+	sch := newScheme(t)
+	vc := netpolVC(nil)
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(vc).Build()
+	r := &VinylCacheReconciler{Client: cli, Scheme: sch}
+
+	require.NoError(t, r.reconcileExporterNetworkPolicy(context.Background(), vc))
+
+	_, err := getExporterNetpol(t, r, vc)
+	assert.True(t, apierrors.IsNotFound(err), "no exporter NetworkPolicy when exporter is disabled")
+}
+
+func TestReconcileExporterNetworkPolicy_RemovedWhenToggledOff(t *testing.T) {
+	sch := newScheme(t)
+	vc := netpolVC(&v1alpha1.ExporterSpec{Enabled: true})
+	cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(vc).Build()
+	r := &VinylCacheReconciler{Client: cli, Scheme: sch}
+
+	require.NoError(t, r.reconcileExporterNetworkPolicy(context.Background(), vc))
+	_, err := getExporterNetpol(t, r, vc)
+	require.NoError(t, err)
+
+	// Toggle the exporter off and reconcile again.
+	vc.Spec.Monitoring.Exporter.Enabled = false
+	require.NoError(t, r.reconcileExporterNetworkPolicy(context.Background(), vc))
+
+	_, err = getExporterNetpol(t, r, vc)
+	assert.True(t, apierrors.IsNotFound(err), "stale exporter NetworkPolicy must be removed when disabled")
+}


### PR DESCRIPTION
Fixes #56.

## Problem

The operator generates NetworkPolicies for the traffic/invalidation/agent ports but **never opens the varnish-exporter port (9131)**. With a default-deny CNI the exporter sidecar is unreachable, so with `monitoring.exporter.enabled` + `serviceMonitor.enabled` the ServiceMonitor target stays **down** and no `varnish_*` metrics reach Prometheus — verified live on operator v0.5.2:

```
health=down url=http://10.42.x.x:9131/metrics
lastError= Get "...:9131/metrics": context deadline exceeded
```

The timeout (not connection-refused) and the fact that an **intra-namespace** curl to `:9131` also times out confirmed it's the NetworkPolicies, not the exporter (which is `Ready` and serves metrics). Allowed ingress ports were `agent→9090`, `intra-cluster→8080,6082`, `invalidation→8080`, `traffic→8080` — `9131` nowhere.

## Fix

`internal/controller/networkpolicy.go`: add `reconcileExporterNetworkPolicy`. When `monitoring.exporter.enabled`, create a `<name>-exporter` policy allowing ingress to the exporter port (default `9131`, honoring `exporter.port`). The policy is removed when the exporter is disabled.

### Design note — allow from all sources

The operator can't know which namespace Prometheus runs in, and the exported data is read-only, low-sensitivity Varnish metrics, so this mirrors `reconcileTrafficNetworkPolicy` (the Varnish HTTP port is already open to all). If you'd prefer scoping to a labeled monitoring namespace (like the operator-namespace selector used by the agent/invalidation policies), happy to switch — but that needs the admin to label the Prometheus namespace, which reintroduces the same out-of-the-box footgun.

## Tests

`internal/controller/networkpolicy_test.go`: enabled (opens 9131, empty `From`, selector `app:<name>`), custom port, disabled (no policy), toggled-off (stale policy removed). `go build/vet/test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)